### PR TITLE
Container static mount + Helm ops + CI/CD wiring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ COPY --from=pybuilder /install /usr/local
 # Copy repository
 COPY . /app
 # Copy built GUI from guibuilder stage
-COPY --from=guibuilder /app/gui/dist /app/src/capsule_brain/gui/static
+# Place built assets where server.py looks for them: /app/src/frontend/dist
+COPY --from=guibuilder /app/gui/dist /app/src/frontend/dist
 RUN chown -R appuser:appuser /app
 USER appuser
 EXPOSE 8000


### PR DESCRIPTION
Summary:
- Dockerfile: copy frontend dist to /app/src/frontend/dist for FastAPI StaticFiles.
- Helm: probes -> /api/healthz; added HPA, PDB, NetworkPolicy, ServiceMonitor, ExternalSecret; imagePullSecrets + generic ServiceAccount; example ClusterSecretStore.
- CI/CD: CI builds/tests (frontend/backend), lints Helm, security scan (Trivy), SBOM (Syft); CD for dev (main) and prod (tag/dispatch).
- Docs: docs/DEPLOYMENT.md for values, secrets, and workflows.

Next steps (config placeholders):
- Configure OIDC auth for your cluster in cd-dev.yml / cd-prod.yml.
- Set image registry (default GHCR) and permissions.
- Enable serviceMonitor/externalSecrets/NetworkPolicy in prod values as needed.
- Define NetworkPolicy ingress/egress for Redis/Neo4j/vLLM/Qdrant.

Test plan:
- Docker build: docker build -t liquid-hive:local .; run: docker run -p 8000:8000 liquid-hive:local; open / and /api/healthz.
- Helm: helm lint helm/liquid-hive; helm template demo helm/liquid-hive -f helm/liquid-hive/values.yaml.