### PR TITLE
Modernize backend + UI: final test wiring and budget UI

### DIFF
--- a/tests/test_admin_guards.py
+++ b/tests/test_admin_guards.py
@@ -1,0 +1,34 @@
+import os
+from starlette.testclient import TestClient
+from unified_runtime.server import app
+
+
+def test_admin_guard_cache_clear_unauthorized(monkeypatch):
+    monkeypatch.setenv('ADMIN_TOKEN', 'secret123')
+    with TestClient(app) as client:
+        r = client.post('/api/cache/clear', json={"pattern": "pytest-noauth"})
+        assert r.status_code == 200
+        assert r.json().get('error') == 'Unauthorized'
+
+
+def test_admin_guard_cache_clear_authorized(monkeypatch):
+    monkeypatch.setenv('ADMIN_TOKEN', 'secret123')
+    with TestClient(app) as client:
+        r = client.post('/api/cache/clear', json={"pattern": "pytest-auth"}, headers={'x-admin-token': 'secret123'})
+        assert r.status_code == 200
+        assert 'error' not in r.json()
+
+
+def test_router_thresholds_guard_flow(monkeypatch):
+    monkeypatch.setenv('ADMIN_TOKEN', 'secretXYZ')
+    with TestClient(app) as client:
+        # Unauthorized
+        r = client.post('/api/admin/router/set-thresholds', json={'conf_threshold': 0.8})
+        assert r.status_code == 200
+        assert r.json().get('error') == 'Unauthorized'
+        # Authorized
+        r = client.post('/api/admin/router/set-thresholds', json={'conf_threshold': 0.8}, headers={'x-admin-token': 'secretXYZ'})
+        assert r.status_code == 200
+        data = r.json()
+        assert 'error' not in data
+        assert isinstance(data, dict)

--- a/tests/test_api_core.py
+++ b/tests/test_api_core.py
@@ -1,0 +1,39 @@
+import os
+from starlette.testclient import TestClient
+from unified_runtime.server import app
+
+
+def test_health_and_core_endpoints():
+    with TestClient(app) as client:
+        r = client.get('/api/healthz')
+        assert r.status_code == 200
+
+        r = client.get('/api/cache/health')
+        assert r.status_code == 200
+
+        r = client.get('/api/cache/analytics')
+        assert r.status_code == 200
+
+        r = client.get('/api/cache/status')
+        assert r.status_code == 200
+
+        r = client.get('/api/swarm/status')
+        assert r.status_code == 200
+
+
+def test_cache_clear_without_admin_token_when_not_required(monkeypatch):
+    # Ensure ADMIN_TOKEN not set for this test
+    monkeypatch.delenv('ADMIN_TOKEN', raising=False)
+    with TestClient(app) as client:
+        r = client.post('/api/cache/clear', json={"pattern": "pytest"})
+        assert r.status_code == 200
+        data = r.json()
+        assert isinstance(data, dict)
+        assert 'error' not in data
+
+
+def test_autopromote_preview():
+    with TestClient(app) as client:
+        r = client.get('/api/autonomy/autopromote/preview')
+        assert r.status_code == 200
+        assert isinstance(r.json(), dict)


### PR DESCRIPTION
- Fix Jest in ESM projects via CJS config, ts-jest, and react-markdown mock
- Add a11y label for file input; stabilize ChatPanel tests
- Add Budget Usage card in SystemPanel wired to /api/budget/status
- Full backend pytest and frontend build/tests passing locally

Please run CI; expect green on backend pytest and frontend build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Budget usage dashboard and public /api/budget/status endpoint with tokens, spend, limits, and reset time.

- Refactor
  - Smarter model routing, Redis-backed budget tracking, and UTC timezone-aware timestamps across services.
  - CI added for backend/frontend; GUI build migrated to frontend with npm; docker-compose YAML normalized.

- Style
  - Accessibility: screen-reader label added to Attach File control.

- Documentation
  - Added architectural roadmap epic for Project Apotheosis.

- Tests
  - New tests for admin guards, core APIs, chat/WebSocket, and budget endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->